### PR TITLE
Add attribute type support to gem

### DIFF
--- a/lib/rusic/uploaders/custom_attributes.rb
+++ b/lib/rusic/uploaders/custom_attributes.rb
@@ -22,7 +22,8 @@ module Rusic
           params_hash['theme']['custom_attributes_attributes'][i] = {
             'key' => key,
             'value' => options.fetch('value'),
-            'help_text' => options.fetch('help_text', '')
+            'help_text' => options.fetch('help_text', ''),
+            'input_type' => options.fetch('type', 'text')
           }
 
           if e_attr = existing_attributes[key]

--- a/lib/rusic/version.rb
+++ b/lib/rusic/version.rb
@@ -1,3 +1,3 @@
 module Rusic
-  VERSION = "1.5.2"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
Rusic now supports attribute types, this gem adds support for setting them from a theme.

See https://github.com/rusic/rusic/pull/575 for Rusic implementation.