### PR TITLE
Add pry and awesome_print as runtime dependencies

### DIFF
--- a/rusic.gemspec
+++ b/rusic.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rest-client', '~> 1.6'
   spec.add_runtime_dependency 'filewatcher', '~> 0.3'
   spec.add_runtime_dependency 'command_line_reporter', '~> 3.3'
+  spec.add_runtime_dependency 'pry'
+  spec.add_runtime_dependency 'awesome_print'
 
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
When these gems were added to the gemfile, they were mistakenly not
added as runtime dependencies. This meant the gem would not correctly
require them when installed through bundler. This was recorded in a
Github issue[1].

This commit adds `pry` and `awesome_print` as runtime dependencies so
they will be correctly required by bundler and the gem will run.

[1] - https://github.com/rusic/rusic-gem/issues/28